### PR TITLE
changes for 2.0

### DIFF
--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -663,6 +663,26 @@ Then use this module.
         # client successfully authenticated
     }
 
+=head1 CHANGES FROM 1.X
+
+The 2.x series of this module provides some significant changes from 1.x. 
+
+With 1.x, fully_authenticated could only suggest that there were no concerns
+and that the client was fully authenticated.  Now, we set this in addition to
+any failure fields.  For this reason it is important to handle failures
+first and then check this response attribute.  Note that the response attribute
+also now shows the full list (not the first) set of possible concerns.
+
+Therefore:
+
+=over
+
+=item One cannot assume that fully_authenticated means "success" and
+
+=item Reasons for failure are no longer exclusive.
+
+=back
+
 =head1 AUTHOR
 
 binary.com, C<perl at binary.com>

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -392,7 +392,12 @@ sub _get_result_proveid {
     }
 
     # check if client is in any suspicious list
-    # we don't care about: NoOfCCJ, COAMatch
+    # we don't care about: COAMatch
+    #
+    # Add NoOfCCJ separately since we don't fail that one.
+
+    $decision->{CCJ} = 1 if $credit_reference->findvalue('NoOfCCJ')
+    
     my @matches =
       map  { $_->[0] }
       grep { $_->[1] > 0 }
@@ -411,6 +416,7 @@ sub _get_result_proveid {
 
     # if client is in Directors list, we should not fully authenticate him
     if ( $report_summary{Directors} ) {
+        $decision->{director} = 1;
         $decision->{matches} = [ @{$decision->{matches}}, 'Directors' ];
     }
 

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -411,7 +411,7 @@ sub _get_result_proveid {
 
     # if client is in Directors list, we should not fully authenticate him
     if ( $report_summary{Directors} ) {
-        $decision->{matches} = [ @{$decision->{matches}, 'Directors' ];
+        $decision->{matches} = [ @{$decision->{matches}}, 'Directors' ];
     }
 
     # check if client can be fully authenticated

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -400,7 +400,7 @@ sub _get_result_proveid {
       qw(BOEMatch PEPMatch OFACMatch CIFASMatch);
 
     if (@matches) {
-        my @hard_fails = grep { $f = $_; 
+        my @hard_fails = grep { my $f = $_; 
                                 grep { "${f}Match" eq $_ } @matches } 
                          qw(BOE PEP OFAC CIFAS);
         $decision->{$_} = 1 for @hard_fails;

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -396,7 +396,7 @@ sub _get_result_proveid {
     #
     # Add NoOfCCJ separately since we don't fail that one.
 
-    $decision->{CCJ} = 1 if $credit_reference->findvalue('NoOfCCJ')
+    $decision->{CCJ} = 1 if $credit_reference->findvalue('NoOfCCJ');
     
     my @matches =
       map  { $_->[0] }

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -580,7 +580,7 @@ Experian::IDAuth - Experian's ID Authenticate service
 
 =head1 VERSION
 
-Version 1.8
+Version 2.0.0
 
 =head1 DESCRIPTION
 
@@ -634,14 +634,19 @@ Then use this module.
         die;
     }
 
-    if ($prove_id_result->{fully_authenticated}) {
-        # client successfully authenticated
-    }
     if ($prove_id_result->{age_verified}) {
         # client's age is verified
     }
     if ($prove_id_result->{deceased} || $prove_id_result->{fraud}) {
         # client flagged as deceased or fraud
+    }
+    if ($prove_id_result->{deny}) {
+        # client on any of PEP, OFAC, or BOE list
+        # you can check $prove_id_result->{PEP} etc if you want more detail
+    }
+    if ($prove_id_result->{fully_authenticated}) {
+        # client successfully authenticated, 
+        # DOES NOT MEAN NO CONCERNS
     }
 
     # CheckID is a more simpler version and can be used if ProveID_KYC fails

--- a/t/decision.t
+++ b/t/decision.t
@@ -1503,7 +1503,7 @@ ok(not exists $result->{fully_authenticated}, 'not authenticated');
 $result = examine($not_deceased),
 is($result->{age_verified}, 1, "Not deceased, age verified");
 is($result->{fully_authenticated}, 1, 'Not deceased, Fully authenticated');
-ok(not exists $result->{deceased}, 'Not deceased, not deceased'
+ok(not exists $result->{deceased}, 'Not deceased, not deceased');
 ok(not exists $result->{deny}, 'Not deceased, not denied');
 
 

--- a/t/decision.t
+++ b/t/decision.t
@@ -2431,7 +2431,7 @@ ok(not(exists $result->{deny}), 'Age only 8, not denied');
 
 $result = examine($age_only_9),
 is($result->{age_verified}, 1, "Age only 9, age verified");
-ok(not(exists $result->{fully_authenticated}), 1, 'Age only 9, not authenticated');
+ok(not(exists $result->{fully_authenticated}), 'Age only 9, not authenticated');
 ok(not(exists $result->{deceased}), 'Age only 9, not deceased');
 ok(not(exists $result->{deny}), 'Age only 9, not denied');
 

--- a/t/decision.t
+++ b/t/decision.t
@@ -1488,28 +1488,41 @@ EOD
 my $result = examine($fully1);
 is($result->{age_verified}, 1, "Fully 1, age verified");
 is($result->{fully_authenticated}, 1, 'Fully 1, Fully authenticated');
-ok(not exists $result->{deny}, 'Fully 1, not denied');
+ok(not(exists $result->{deny}), 'Fully 1, not denied');
 
 $result = examine($fully2);
 is($result->{age_verified}, 1, "Fully 2, age verified");
 is($result->{fully_authenticated}, 1, 'Fully 2, Fully authenticated');
-ok(not exists $result->{deny}, 'Fully 2, not denied');
+ok(not(exists $result->{deny}), 'Fully 2, not denied');
 
 $result = examine($not_authenticated);
-ok(not exists $result->{deny}, 'not authenticated, not denied');
-ok(not exists $result->{age_verified}, 'not authenticated, not age verified');
-ok(not exists $result->{fully_authenticated}, 'not authenticated');
+ok(not(exists $result->{deny}), 'not authenticated, not denied');
+ok(not(exists $result->{age_verified}), 'not authenticated, not age verified');
+ok(not(exists $result->{fully_authenticated}), 'not authenticated');
 
 $result = examine($not_deceased),
 is($result->{age_verified}, 1, "Not deceased, age verified");
 is($result->{fully_authenticated}, 1, 'Not deceased, Fully authenticated');
-ok(not exists $result->{deceased}, 'Not deceased, not deceased');
-ok(not exists $result->{deny}, 'Not deceased, not denied');
+ok(not(exists $result->{deceased}), 'Not deceased, not deceased');
+ok(not(exists $result->{deny}), 'Not deceased, not denied');
 
+$result = examine($deceased);
+is($result->{age_verified}, 1, "deceased, age verified");
+is($result->{fully_authenticated}, 1, 'deceased, Fully authenticated');
+is($result->{deceased}, 1, 'deceased, deceased');
+ok(not(exists $result->{deny}), 'deceased, not denied');
 
-eq_or_diff(examine($deceased),    {deceased => 1}, "Found deceased in report summary");
-eq_or_diff(examine($cr_deceased), {deceased => 1}, "Found deceased in credit reference");
-eq_or_diff(examine($fraud),       {fraud    => 1}, "Found fraud in report summary");
+$result = examine($cr_deceased);
+is($result->{age_verified}, 1, "cr deceased, age verified");
+is($result->{fully_authenticated}, 1, 'cr deceased, Fully authenticated');
+is($result->{deceased}, 1, 'cr deceased, deceased');
+ok(not(exists $result->{deny}), 'cr deceased, not denied');
+
+$result = examine($fraud);
+is($result->{age_verified}, 1, "fraud, age verified");
+is($result->{fully_authenticated}, 1, 'fraud, Fully authenticated');
+is($result->{fraud}, 1, 'fraud, fraud');
+ok(not(exists $result->{deny}), 'fraud, not denied');
 
 # this one has 2 in KYCSummary, so should be fully authenticated
 my $age_only_1 =<<EOD;

--- a/t/decision.t
+++ b/t/decision.t
@@ -1485,31 +1485,28 @@ my $fraud =<<EOD;
 </Search>
 EOD
 
-eq_or_diff(
-    examine($fully1),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "Fully1 fully authenticated"
-);
-eq_or_diff(
-    examine($fully2),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "Fully2 fully authenticated"
-);
-eq_or_diff(examine($not_authenticated), {}, "Not authenticated as expected");
-eq_or_diff(
-    examine($not_deceased),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "Deceased with low certainty level was fully authenticated"
-);
+my $result = examine($fully1);
+is($result->{age_verified}, 1, "Fully 1, age verified");
+is($result->{fully_authenticated}, 1, 'Fully 1, Fully authenticated');
+ok(not exists $result->{deny}, 'Fully 1, not denied');
+
+$result = examine($fully2);
+is($result->{age_verified}, 1, "Fully 2, age verified");
+is($result->{fully_authenticated}, 1, 'Fully 2, Fully authenticated');
+ok(not exists $result->{deny}, 'Fully 2, not denied');
+
+$result = examine($not_authenticated);
+ok(not exists $result->{deny}, 'not authenticated, not denied');
+ok(not exists $result->{age_verified}, 'not authenticated, not age verified');
+ok(not exists $result->{fully_authenticated}, 'not authenticated');
+
+$result = examine($not_deceased),
+is($result->{age_verified}, 1, "Not deceased, age verified");
+is($result->{fully_authenticated}, 1, 'Not deceased, Fully authenticated');
+ok(not exists $result->{deceased}, 'Not deceased, not deceased'
+ok(not exists $result->{deny}, 'Not deceased, not denied');
+
+
 eq_or_diff(examine($deceased),    {deceased => 1}, "Found deceased in report summary");
 eq_or_diff(examine($cr_deceased), {deceased => 1}, "Found deceased in credit reference");
 eq_or_diff(examine($fraud),       {fraud    => 1}, "Found fraud in report summary");

--- a/t/decision.t
+++ b/t/decision.t
@@ -2374,32 +2374,33 @@ my $age_only_10 =<<EOD;
 </Search>
 EOD
 
-eq_or_diff(
-    examine($age_only_1),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "Two in KYC Summary so fully authenticated"
-);
+$result = examine($age_only_1),
+is($result->{age_verified}, 1, "Age only 1, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 1, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 1, not deceased');
+ok(not(exists $result->{deny}), 'Age only 1, not denied');
 
-eq_or_diff(
-    examine($age_only_2),
-    {
-        deny => 1,
-        matches      => ['PEPMatch'],
-    },
-    "    if PEP is set, then fail verification"
-);
+$result = examine($age_only_2),
+is($result->{age_verified}, 1, "Age only 2, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 2, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 2, not deceased');
+is($result->{deny}, 1, 'Age only 2, denied');
+is($result->{PEP}, 1, 'Age only 2, PEP flagged');
 
-eq_or_diff(
-    examine($age_only_3),
-    {
-        deny => 1,
-        matches      => ['BOEMatch'],
-    },
-    "    if BOEMatch is set, then fail verification"
-);
+$result = examine($age_only_3),
+is($result->{age_verified}, 1, "Age only 3, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 3, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 3, not deceased');
+is($result->{deny}, 1, 'Age only 3, denied');
+is($result->{BOE}, 1, 'Age only 3, BOE flagged');
+
+$result = examine($age_only_4),
+is($result->{age_verified}, 1, "Age only 4, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 4, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 4, not deceased');
+is($result->{deny}, 1, 'Age only 4, denied');
+is($result->{OFAC}, 1, 'Age only 4, OFAC flagged');
+
 
 eq_or_diff(
     examine($age_only_4),

--- a/t/decision.t
+++ b/t/decision.t
@@ -2401,62 +2401,45 @@ ok(not(exists $result->{deceased}), 'Age only 4, not deceased');
 is($result->{deny}, 1, 'Age only 4, denied');
 is($result->{OFAC}, 1, 'Age only 4, OFAC flagged');
 
+#Change of address handling
+$result = examine($age_only_5),
+is($result->{age_verified}, 1, "Age only 5, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 5, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 5, not deceased');
+ok(not(exists $result->{deny}), 'Age only 5, not denied');
 
-eq_or_diff(
-    examine($age_only_4),
-    {
-        deny    => 1,
-        matches => ['OFACMatch'],
-    },
-    "    if OFACMatch is set, then fail verification"
-);
+$result = examine($age_only_6),
+is($result->{age_verified}, 1, "Age only 6, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 6, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 6, not deceased');
+is($result->{deny}, 1, 'Age only 6, denied');
+is($result->{CIFAS}, 1, 'Age only 6, CIFAS flagged');
 
-eq_or_diff(
-    examine($age_only_5),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "    ignore COAMatch if set, fully authenticate if possible"
-);
+$result = examine($age_only_7),
+is($result->{age_verified}, 1, "Age only 7, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 7, Fully authenticated');
+is($result->{CCJ}, 1, 'Age only 7, Has court judgements');
+ok(not(exists $result->{deceased}), 'Age only 7, not deceased');
+ok(not(exists $result->{deny}), 'Age only 7, not denied');
 
-eq_or_diff(
-    examine($age_only_6),
-    {
-        deny    => 1,
-        matches => ['CIFASMatch'],
-    },
-    "    if CIFASMatch is set, then fail verification"
-);
+$result = examine($age_only_8),
+is($result->{age_verified}, 1, "Age only 8, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 8, Fully authenticated');
+is($result->{Director}, 1, 'Age only 8, Is Director');
+ok(not(exists $result->{deceased}), 'Age only 8, not deceased');
+ok(not(exists $result->{deny}), 'Age only 8, not denied');
 
-eq_or_diff(
-    examine($age_only_7),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "    ignore CCJs if set, fully authenticate if possible"
-);
+$result = examine($age_only_9),
+is($result->{age_verified}, 1, "Age only 9, age verified");
+ok(not(exists $result->{fully_authenticated}), 1, 'Age only 9, not authenticated');
+ok(not(exists $result->{deceased}), 'Age only 9, not deceased');
+ok(not(exists $result->{deny}), 'Age only 9, not denied');
 
-eq_or_diff(
-    examine($age_only_8),
-    {
-        age_verified => 1,
-        matches      => ['Directors'],
-    },
-    "    if Director, then age_verified only"
-);
-
-eq_or_diff(examine($age_only_9), {age_verified => 1,}, "If KYC Summary is 1, then age_verified");
-
-eq_or_diff(
-    examine($age_only_10),
-    {
-        age_verified        => 1,
-        fully_authenticated => 1,
-    },
-    "If Total number of verifications in Credit reference is 2, then fully_authenticated"
-);
+$result = examine($age_only_10),
+is($result->{age_verified}, 1, "Age only 10, age verified");
+is($result->{fully_authenticated}, 1, 'Age only 10, Fully authenticated');
+ok(not(exists $result->{deceased}), 'Age only 10, not deceased');
+ok(not(exists $result->{deny}), 'Age only 10, not denied');
 
 Test::NoWarnings::had_no_warnings();
 done_testing;

--- a/t/decision.t
+++ b/t/decision.t
@@ -2425,7 +2425,7 @@ ok(not(exists $result->{deny}), 'Age only 7, not denied');
 $result = examine($age_only_8),
 is($result->{age_verified}, 1, "Age only 8, age verified");
 is($result->{fully_authenticated}, 1, 'Age only 8, Fully authenticated');
-is($result->{Director}, 1, 'Age only 8, Is Director');
+is($result->{director}, 1, 'Age only 8, Is Director');
 ok(not(exists $result->{deceased}), 'Age only 8, not deceased');
 ok(not(exists $result->{deny}), 'Age only 8, not denied');
 

--- a/t/xml_report.t
+++ b/t/xml_report.t
@@ -10,8 +10,10 @@ use Data::Dumper;
 use lib 'lib';
 use_ok( 'Experian::IDAuth' );
 
-# clean up
-system "rm -rf /tmp/proveid/";
+my $tmp = $ENV{TEMP} || '/tmp'; # portability between windows and linux
+
+unlink $_ for <"$tmp/proveid/*">;
+rmdir "$tmp/proveid/*";
 
 my $module = Test::MockModule->new('SOAP::Lite');
 my $xml;


### PR DESCRIPTION
This is  a major.backwards-incompatible set of changes to this module  Because there are opportunities to break things, I want to put here the reasons for the changes and an assessment of the possible problems.

Prior to these changes ordering of checks was assumed to be the responsibility of this module.  However the ordering itself is business-specific (different businesses may weigh different criteria differently) and proved to be brittle.  Since this is a public module, it is a bad idea to have business-specific logic in it.

So what this does is returns the *full* set of concerns from the report back to the calling application.  This means that instead of an ordered series of checks with one key set, you now get a hashref woth all applicable keys set.  If Experian thinks the individual is on a PEP and a terrorism list, and the age verification has failed, the application has to decide what to do about these three.

This also means that it is possible to get a full verification result along with a deny so code needs to be audited before upgrade regarding the handling of the order (not that the order didn't pose risks in the current version, but the problems are different here).