### PR TITLE
Ct/logger

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,3 @@
-1.9    2015-11-24
+2.0    2015-11-24
    * Added changes file
    * Removed logger support and added warnings instead

--- a/Changes
+++ b/Changes
@@ -1,0 +1,3 @@
+1.9    2015-11-24
+   * Added changes file
+   * Removed logger support and added warnings instead

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -2,7 +2,7 @@ package Experian::IDAuth;
 use strict;
 use warnings;
 
-our $VERSION = '1.9';
+our $VERSION = '2.0.0';
 
 use Locale::Country;
 use Path::Tiny;

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -584,15 +584,11 @@ with your own data.
     use warnings;
     use base 'Experian::IDAuth';
 
-    # if you're using a logger
-    use Log::Log4perl;
-
     sub defaults {
         my $self = shift;
 
         return (
             $self->SUPER::defaults,
-            logger        => Log::Log4perl::get_logger,
             username      => 'my_user',
             password      => 'my_pass',
             residence     => $residence,

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -40,6 +40,8 @@ sub set {
     return $self;
 }
 
+sub get_result {
+    my $self = shift;
     $self->_do_192_authentication || return;
     for ( $self->{search_option} ) {
         /ProveID_KYC/ && return $self->_get_result_proveid;

--- a/lib/Experian/IDAuth.pm
+++ b/lib/Experian/IDAuth.pm
@@ -2,7 +2,7 @@ package Experian::IDAuth;
 use strict;
 use warnings;
 
-our $VERSION = '1.8';
+our $VERSION = '1.9';
 
 use Locale::Country;
 use Path::Tiny;

--- a/t/get_result_check_id.t
+++ b/t/get_result_check_id.t
@@ -307,9 +307,11 @@ my $prove_id = Experian::IDAuth->new(
     premise       => 'premise',
 );
 
-my $prove_id_result = $prove_id->get_result();
+warning_like( sub {
+  my $prove_id_result = $prove_id->get_result();
 
-ok ($prove_id_result == 0, 'check_id failed');
+  ok ($prove_id_result == 0, 'check_id failed');
+}, qr/not a pdf/, 'bad pdf warning');
 
 Test::NoWarnings::had_no_warnings();
 done_testing;

--- a/t/get_result_prove_id.t
+++ b/t/get_result_prove_id.t
@@ -307,10 +307,12 @@ my $prove_id = Experian::IDAuth->new(
     premise       => 'premise',
 );
 
-my $prove_id_result = $prove_id->get_result();
+warning_like( sub {
+   my $prove_id_result = $prove_id->get_result();
 
-ok ($prove_id_result->{fully_authenticated}, 'fully authenticated');
-ok ($prove_id_result->{age_verified}, 'age verified');
+   ok ($prove_id_result->{fully_authenticated}, 'fully authenticated');
+   ok ($prove_id_result->{age_verified}, 'age verified');
+}, qr/not a pdf/, 'Bad pdf warning');
 
 Test::NoWarnings::had_no_warnings();
 done_testing;

--- a/t/xml_report.t
+++ b/t/xml_report.t
@@ -308,11 +308,12 @@ my $prove_id = Experian::IDAuth->new(
     premise       => 'premise',
 );
 
-my $prove_id_result = $prove_id->get_result();
-my $xml_report = $prove_id->get_192_xml_report();
+warning_like( sub {
+    my $prove_id_result = $prove_id->get_result();
+    my $xml_report = $prove_id->get_192_xml_report();
 
-ok ($xml_report eq $xml, 'get_192_xml_report');
-
+    ok ($xml_report eq $xml, 'get_192_xml_report');
+}, qr/not a pdf/, 'bad pdf warning');
 Test::NoWarnings::had_no_warnings();
 done_testing;
 


### PR DESCRIPTION
This removes the use of the logger from this module.  I had considered leaving it in for third parties however the following considerations weighed against it:

1.  the logger itself always logged under the log level of info, which meant that things which probably should be warnings were not.
2.  Making warn vs logger behavior consistent is impossible
3.  Without a logger, warnings get ignored.